### PR TITLE
Use proper type for start time

### DIFF
--- a/GeigerNano.ino
+++ b/GeigerNano.ino
@@ -38,8 +38,8 @@ int AVGCPM = 0;                           // variable containing the floating av
 volatile int Counts1 = 0;                 // variable containing the number of GM Tube events within the LOGtime
 volatile int Counts2 = 0;                 // tube 2
 
-bool Starting = true;                     // 
-int Start;
+bool Starting = true;                     //
+unsigned long Start;                      // Track start time in milliseconds
 
 #ifdef TEST_INT
 volatile int INT = 0;                     // Flag for tracking whether we're within interrupt. Shouldn't end up set, but for debugging


### PR DESCRIPTION
## Summary
- Store start time as `unsigned long` to preserve full `millis()` value

## Testing
- `gcc -x c++ -fsyntax-only GeigerNano.ino` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68985a3f1e708332a894507fd25ac55b