### PR TITLE
Use 32-bit CPM accumulator

### DIFF
--- a/GeigerNano.ino
+++ b/GeigerNano.ino
@@ -34,7 +34,7 @@ volatile unsigned long Coincidence = 0;   // Count of coincidences
 int COUNTS[Period];                       // array for storing the measured amounts of impulses in 10 consecutive 1 second periods
 int Slot = 0;                             // pointer to round robin location in COUNTS
 
-int AVGCPM = 0;                           // variable containing the floating average number of counts over a fixed moving window period
+unsigned long AVGCPM = 0;                 // variable containing the floating average number of counts over a fixed moving window period
 volatile int Counts1 = 0;                 // variable containing the number of GM Tube events within the LOGtime
 volatile int Counts2 = 0;                 // tube 2
 
@@ -89,7 +89,7 @@ void setup() {
     interrupts();
 
     // SURVEY METER: If current second indicates large change, reset to new CPM
-    if (!Starting && abs((counts1 + counts2) * Period - AVGCPM) > 1000) {
+    if (!Starting && labs(((long)counts1 + (long)counts2) * Period - (long)AVGCPM) > 1000) {
       Starting = true;
       for (int idx = 0; idx < Period; idx++) {
         COUNTS[idx] = counts1 + counts2;


### PR DESCRIPTION
## Summary
- avoid overflow in minute CPM accumulator by using unsigned long
- ensure large changes detection handles 32-bit values safely

## Testing
- `g++ -x c++ -c GeigerNano.ino` *(fails: fatal error: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68985ec710fc8332b9a1c07db8354381