### PR TITLE
Fix interrupt attachment for GeigerNano

### DIFF
--- a/GeigerNano.ino
+++ b/GeigerNano.ino
@@ -5,6 +5,9 @@
 
 // Pin which may enable piezo speaker when HIGH, leave undefined for quiet
 #define SOUND_PIN 8
+// Pins used for the two tube inputs
+#define TUBE1_PIN 2
+#define TUBE2_PIN 3
 // Use IAEA thresholds for radiation safety. WARNING: May not be able to measure that high rate, false sense of security
 // #define IAEA_THRESHOLDS
 // Hardware test, check for nested interrupts or code running during interrupt, normally comment this out
@@ -182,8 +185,8 @@ void setup() {
 
   Serial.begin(9600);
 
-  attachInterrupt(0, IMPULSE1, FALLING);
-  attachInterrupt(1, IMPULSE2, FALLING);
+  attachInterrupt(digitalPinToInterrupt(TUBE1_PIN), IMPULSE1, FALLING);
+  attachInterrupt(digitalPinToInterrupt(TUBE2_PIN), IMPULSE2, FALLING);
   Start = millis();
 }
 


### PR DESCRIPTION
## Summary
- define constants for Geiger tube pins and use `digitalPinToInterrupt` for portability

## Testing
- `g++ -x c++ -c GeigerNano.ino` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898606dfe388332864b7cfc451d032d