### PR TITLE
Ensure custom LCD symbol renders correctly

### DIFF
--- a/GeigerNano.ino
+++ b/GeigerNano.ino
@@ -132,7 +132,7 @@ void setup() {
     lcd.setCursor(0, 0);
     // lcd.print("CPM=");                              // Matches original sketch, but isn't it kinda obvious? Save space for stddev
     lcd.print(AVGCPM);
-    lcd.print(char(0));                                // The +/- symbol
+    lcd.write((uint8_t)0);                             // The +/- symbol
     lcd.print(STDCPM);
 
 #ifdef TEST_INT


### PR DESCRIPTION
## Summary
- use lcd.write for custom plus/minus symbol on LCD

## Testing
- `arduino-cli compile --fqbn arduino:avr:nano:cpu=atmega328 --warnings all` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898606dfe388332864b7cfc451d032d