### PR TITLE
Initialize dead time tracker to record first interval

### DIFF
--- a/GeigerNano.ino
+++ b/GeigerNano.ino
@@ -46,7 +46,9 @@ volatile int INT = 0;                     // Flag for tracking whether we're wit
 bool WasInt = false;                      // Debugging flag to see if we've run during interrupt handling, which would be bad.
 #endif
 
-volatile unsigned long DeadTime = 99999;  //
+// Track the shortest interval between counts. Initialise to the maximum so
+// the first measurement is always recorded.
+volatile unsigned long DeadTime = 0xFFFFFFFFUL;
 volatile unsigned long LastTick1 = 0;
 volatile unsigned long LastTick2 = 0;     // tube 2
 


### PR DESCRIPTION
## Summary
- Correct dead-time tracker initial value so the first pulse interval is captured instead of defaulting to a stale constant

## Testing
- `g++ -fsyntax-only -x c++ GeigerNano.ino` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6898606dfe388332864b7cfc451d032d