### PR TITLE
Fix missing TaskManagerIO dependency

### DIFF
--- a/GeigerNano.ino
+++ b/GeigerNano.ino
@@ -2,6 +2,7 @@
 #include <Arduino.h>
 #include <LiquidCrystalIO.h>
 #include <SPI.h>
+#include <TaskManagerIO.h>
 
 // Pin which may enable piezo speaker when HIGH, leave undefined for quiet
 #define SOUND_PIN 8


### PR DESCRIPTION
## Summary
- include TaskManagerIO header so taskManager is defined

## Testing
- `arduino-builder -hardware /usr/share/arduino/hardware -tools /usr/bin -libraries /usr/share/arduino/libraries -build-path /tmp/build -fqbn arduino:avr:nano GeigerNano.ino` *(fails: missing device or architecture after '-mmcu=')*

------
https://chatgpt.com/codex/tasks/task_e_68986294636c8332ac847c40788aecbe