### PR TITLE
Fix missing semicolon in LCD initialization macro

### DIFF
--- a/GeigerNano.ino
+++ b/GeigerNano.ino
@@ -23,7 +23,7 @@
 // use a custom configuration as you see in many other examples.
 
 // If your backpack is wired RS,RW,EN then use this version
-LiquidCrystalI2C_RS_EN(lcd, 0x27, false)
+LiquidCrystalI2C_RS_EN(lcd, 0x27, false);
 
 // If your backpack is wired EN,RW,RS then use this version instead of the above.
 //LiquidCrystalI2C_EN_RS(lcd, 0x20, false)


### PR DESCRIPTION
## Summary
- Add missing semicolon after `LiquidCrystalI2C_RS_EN` macro call in `GeigerNano.ino`

## Testing
- `g++ -c -x c++ GeigerNano.ino` *(fails: fatal error: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68986294636c8332ac847c40788aecbe