### PR TITLE
Fix non-volatile interrupt flags

### DIFF
--- a/GeigerNano.ino
+++ b/GeigerNano.ino
@@ -45,8 +45,8 @@ bool Starting = true;                     // Flag tracking initial sampling peri
 unsigned long Start;                      // Millis value when logging started; must be 32-bit
 
 #ifdef TEST_INT
-volatile int INT = 0;                     // Flag for tracking whether we're within interrupt. Shouldn't end up set, but for debugging
-bool WasInt = false;                      // Debugging flag to see if we've run during interrupt handling, which would be bad.
+volatile bool INT = false;                // Flag for tracking whether we're within interrupt. Shouldn't end up set, but for debugging
+volatile bool WasInt = false;             // Debugging flag to see if we've run during interrupt handling, which would be bad.
 #endif
 
 // Track the shortest interval between counts. Initialise to the maximum so


### PR DESCRIPTION
## Summary
- mark interrupt tracking flags as volatile booleans to ensure atomic access

## Testing
- `cppcheck --enable=all --inline-suppr --quiet GeigerNano.ino`

------
https://chatgpt.com/codex/tasks/task_e_68986294636c8332ac847c40788aecbe